### PR TITLE
fix: override auth info if secret already exists

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = fmt, lint, unit
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
 lib_path = {toxinidir}/lib/charms/storage_libs
-all_path = {[vars]src_path} {[vars]tst_path} 
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 setenv =
@@ -47,7 +47,6 @@ commands =
         --skip {toxinidir}/venv \
         --skip {toxinidir}/.mypy_cache \
         --skip {toxinidir}/icon.svg
-    
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 


### PR DESCRIPTION
This can be triggered by leaving and joining the cephfs-share relation, which errored before this change.

## How was the code tested?

An additional test that verifies that setting the share twice with different auth data succeeds.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
